### PR TITLE
Add logging, dependencies, and updates to file listeners and

### DIFF
--- a/application/probebox/.gitignore
+++ b/application/probebox/.gitignore
@@ -1,0 +1,4 @@
+log/*
+!log/.keep
+catalogs/*
+!catalogs/.keep

--- a/application/probebox/daanse.probebox.bndrun
+++ b/application/probebox/daanse.probebox.bndrun
@@ -46,7 +46,8 @@
 	bnd.identity;id='org.eclipse.daanse.jdbc.db.importer.csv',\
 	bnd.identity;id='org.gecko.emf.osgi.component',\
 	bnd.identity;id='org.eclipse.daanse.sql.guard.api',\
-	bnd.identity;id='org.eclipse.daanse.sql.guard.jsqltranspiler'
+	bnd.identity;id='org.eclipse.daanse.sql.guard.jsqltranspiler',\
+	bnd.identity;id='org.eclipse.daanse.rolap.core'
 
 
 # This will help us keep -runbundles sorted
@@ -89,9 +90,13 @@
 	org.eclipse.daanse.mdx.parser.ccc;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.common;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.olap.format;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.olap.spi;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.olap.xmla.bridge;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.rolap.core;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.rolap.mapping.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.rolap.mapping.emf;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.rolap.mapping.pojo;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.server.application.probebox;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.sql.guard.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.sql.guard.jsqltranspiler;version='[0.0.1,0.0.2)',\

--- a/application/probebox/logback.xml
+++ b/application/probebox/logback.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<configuration>
+
+  <import
+    class="ch.qos.logback.classic.jul.LevelChangePropagator" />
+  <contextListener class="LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+
+  <appender name="STDOUT"
+    class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ROLL_FILE"
+    class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>log/log.log</file>
+    <rollingPolicy
+      class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>log/log.log-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <!-- each archived file's size will be max 10MB -->
+      <maxFileSize>10MB</maxFileSize>
+      <!-- 30 days to keep -->
+      <maxHistory>30</maxHistory>
+      <!-- total size of all archive files, if total size > 100MB, it will
+      delete old archived file -->
+      <totalSizeCap>100MB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="TRACE">
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="ROLL_FILE" />
+  </root>
+</configuration>

--- a/application/probebox/pom.xml
+++ b/application/probebox/pom.xml
@@ -84,5 +84,6 @@
       <artifactId>slf4j-api</artifactId>
       <scope>compile</scope>
     </dependency>
+
   </dependencies>
 </project>

--- a/application/probebox/src/main/java/org/eclipse/daanse/server/application/probebox/CatalogXmiFileListener.java
+++ b/application/probebox/src/main/java/org/eclipse/daanse/server/application/probebox/CatalogXmiFileListener.java
@@ -37,7 +37,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@FileSystemWatcherListenerProperties(recursive = true, pattern = "catalog.xmi")
+@FileSystemWatcherListenerProperties(recursive = true, pattern = ".*.xmi")
 @Component(service = FileSystemWatcherListener.class, configurationPid = CatalogXmiFileListener.PID, configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class CatalogXmiFileListener implements FileSystemWatcherListener {
 

--- a/application/probebox/src/main/java/org/eclipse/daanse/server/application/probebox/ProbeBoxFileListener.java
+++ b/application/probebox/src/main/java/org/eclipse/daanse/server/application/probebox/ProbeBoxFileListener.java
@@ -18,6 +18,7 @@ import static org.eclipse.daanse.jdbc.datasource.metatype.h2.api.Constants.DATAS
 import static org.eclipse.daanse.jdbc.datasource.metatype.h2.api.Constants.OPTION_PLUGABLE_FILESYSTEM_MEM_FS;
 import static org.eclipse.daanse.jdbc.datasource.metatype.h2.api.Constants.PID_DATASOURCE;
 import static org.eclipse.daanse.jdbc.db.importer.csv.api.Constants.PID_CSV_DATA_IMPORTER;
+import static org.eclipse.daanse.rolap.core.api.Constants.BASIC_CONTEXT_PID;
 import static org.eclipse.daanse.rolap.core.api.Constants.BASIC_CONTEXT_REF_NAME_CATALOG_MAPPING_SUPPLIER;
 import static org.eclipse.daanse.rolap.core.api.Constants.BASIC_CONTEXT_REF_NAME_DATA_SOURCE;
 import static org.eclipse.daanse.rolap.core.api.Constants.BASIC_CONTEXT_REF_NAME_DIALECT_FACTORY;
@@ -176,8 +177,7 @@ public class ProbeBoxFileListener implements FileSystemWatcherListener {
 
     private void createContext(Path path, String matcherKey) throws IOException {
 
-        Configuration configContext = ca.getFactoryConfiguration(
-                org.eclipse.daanse.rolap.core.api.Constants.BASIC_CONTEXT_PID, UUID.randomUUID().toString(), "?");
+        Configuration configContext = ca.getFactoryConfiguration(BASIC_CONTEXT_PID, UUID.randomUUID().toString(), "?");
 
         Dictionary<String, Object> props = new Hashtable<>();
         props.put(BASIC_CONTEXT_REF_NAME_DATA_SOURCE + TARGET_EXT, filterOfMatcherKey(matcherKey));


### PR DESCRIPTION
configurations

- Add `.gitignore` for logs and catalogs with `.keep` files
- Update `bndrun` file with new bundles and dependencies
- Add `logback.xml` for logging configuration with rolling policy
- Update `pom.xml` to include `slf4j-api` dependency
- Modify file listener patterns to support all `.xmi` files
- Refactor constants usage in `ProbeBoxFileListener` for clarity
