### PR TITLE
Add Dockerfile and update port configuration for probe application

### DIFF
--- a/application/probe/container/Dockerfile
+++ b/application/probe/container/Dockerfile
@@ -1,0 +1,40 @@
+#*******************************************************************************
+# Copyright (c)  2025 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+#   Contributors:
+#   SmartCity Jena - initial
+#   Stefan Bischof (bipolis.org) - initial
+#*******************************************************************************
+
+FROM eclipse-temurin:24-jre-alpine
+
+# Create non-root user for security
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Set working directory
+WORKDIR /app
+
+# Copy application files
+COPY --chown=appuser:appgroup ../target/daanse.probe.jar /app/
+COPY --chown=appuser:appgroup ../start /app/
+COPY --chown=appuser:appgroup ../logback.xml /app/
+COPY --chown=appuser:appgroup ../catalog/ /app/catalog/
+COPY --chown=appuser:appgroup ../log/ /app/log/
+
+# Make start script executable
+RUN chmod +x /app/start
+
+# Switch to non-root user
+USER appuser
+
+# Expose common application port (adjust as needed)
+EXPOSE 8080
+
+# Use shell script as entrypoint
+ENTRYPOINT ["/app/start"]

--- a/application/probe/daanse.probe.bndrun
+++ b/application/probe/daanse.probe.bndrun
@@ -16,7 +16,7 @@
 
 -runproperties: \
     org.slf4j.simpleLogger.defaultLogLevel=error,\
-	org.osgi.service.http.port=8090,\
+	org.osgi.service.http.port=8080,\
     logback.configurationFile=./logback.xml
 
 -runpath: \


### PR DESCRIPTION
- Add Dockerfile for containerizing the probe application
- Create non-root user and set up application directory in Dockerfile
- Copy application files and set entrypoint in Dockerfile
- Expose port 8080 in Dockerfile for the application
- Update `daanse.probe.bndrun` to use port 8080 instead of 8090
- Add placeholder `README.md` for container directory
